### PR TITLE
[master] vendor: broadcom: 4359: Do not use AOSP overlay

### DIFF
--- a/bcmdhd/firmware/bcm4359/device-bcm.mk
+++ b/bcmdhd/firmware/bcm4359/device-bcm.mk
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
--include hardware/broadcom/wlan/bcmdhd/config/config-bcm.mk
-
 BCM_FW_SRC_FILE_STA := fw_bcmdhd.bin
 BCM_FW_SRC_FILE_AP  := fw_bcmdhd_apsta.bin
 
 PRODUCT_COPY_FILES += \
     vendor/broadcom/wlan/bcmdhd/firmware/bcm4359/$(BCM_FW_SRC_FILE_STA):$(TARGET_COPY_OUT_VENDOR)/firmware/fw_bcmdhd.bin \
-    vendor/broadcom/wlan/bcmdhd/firmware/bcm4359/$(BCM_FW_SRC_FILE_AP):$(TARGET_COPY_OUT_VENDOR)/firmware/fw_bcmdhd_apsta.bin
+    vendor/broadcom/wlan/bcmdhd/firmware/bcm4359/$(BCM_FW_SRC_FILE_AP):$(TARGET_COPY_OUT_VENDOR)/firmware/fw_bcmdhd_apsta.bin \
+    vendor/broadcom/wlan/bcmdhd/firmware/bcm4359/wpa_supplicant_overlay.conf:system/etc/wifi/wpa_supplicant_overlay.conf \
+    vendor/broadcom/wlan/bcmdhd/firmware/bcm4359/p2p_supplicant_overlay.conf:system/etc/wifi/p2p_supplicant_overlay.conf

--- a/bcmdhd/firmware/bcm4359/p2p_supplicant_overlay.conf
+++ b/bcmdhd/firmware/bcm4359/p2p_supplicant_overlay.conf
@@ -1,0 +1,4 @@
+disable_scan_offload=1
+p2p_no_go_freq=5170-5740
+p2p_search_delay=0
+no_ctrl_interface=

--- a/bcmdhd/firmware/bcm4359/wpa_supplicant_overlay.conf
+++ b/bcmdhd/firmware/bcm4359/wpa_supplicant_overlay.conf
@@ -1,0 +1,4 @@
+disable_scan_offload=1
+p2p_disabled=1
+filter_rssi=-75
+no_ctrl_interface=


### PR DESCRIPTION
"wowlan" is not working at 4.4 kernel and it is present in
AOSP wpa/p2p suplicant overlay.

So do not include AOSP one.

Signed-off-by: Humberto Borba <humberos@gmail.com>