### PR TITLE
[master] vendor: broadcom: 4359: Do not use AOSP overlay

### DIFF
--- a/bcmdhd/firmware/bcm4359/device-bcm.mk
+++ b/bcmdhd/firmware/bcm4359/device-bcm.mk
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
--include hardware/broadcom/wlan/bcmdhd/config/config-bcm.mk
-
 BCM_FW_SRC_FILE_STA := fw_bcmdhd.bin
 BCM_FW_SRC_FILE_AP  := fw_bcmdhd_apsta.bin
 


### PR DESCRIPTION
Call aosp config from platform/device if it is necesssary.

Signed-off-by: Humberto Borba <humberos@gmail.com>