### PR TITLE
device-bcm-vendor: copy fw to paths to path required by brcmfmac

### DIFF
--- a/bcmdhd/firmware/bcm43455/device-bcm-vendor.mk
+++ b/bcmdhd/firmware/bcm43455/device-bcm-vendor.mk
@@ -20,3 +20,8 @@ BCM_FW_SRC_FILE_AP  := fw_bcmdhd_apsta.bin
 PRODUCT_COPY_FILES += \
     vendor/broadcom/wlan/bcmdhd/firmware/bcm43455/$(BCM_FW_SRC_FILE_STA):$(TARGET_COPY_OUT_VENDOR)/firmware/fw_bcmdhd.bin \
     vendor/broadcom/wlan/bcmdhd/firmware/bcm43455/$(BCM_FW_SRC_FILE_AP):$(TARGET_COPY_OUT_VENDOR)/firmware/fw_bcmdhd_apsta.bin
+
+ifeq ($(WIFI_DRIVER_BUILT),brcmfmac)
+PRODUCT_COPY_FILES += \
+    vendor/broadcom/wlan/bcmdhd/firmware/bcm43455/$(BCM_FW_SRC_FILE_STA):$(TARGET_COPY_OUT_VENDOR)/firmware/brcm/brcmfmac43455-sdio.bin
+endif

--- a/bcmdhd/firmware/bcm4359/device-bcm-vendor.mk
+++ b/bcmdhd/firmware/bcm4359/device-bcm-vendor.mk
@@ -18,3 +18,8 @@ BCM_FW_SRC_FILE_AP  := fw_bcmdhd_apsta.bin
 PRODUCT_COPY_FILES += \
     vendor/broadcom/wlan/bcmdhd/firmware/bcm4359/$(BCM_FW_SRC_FILE_STA):$(TARGET_COPY_OUT_VENDOR)/firmware/fw_bcmdhd.bin \
     vendor/broadcom/wlan/bcmdhd/firmware/bcm4359/$(BCM_FW_SRC_FILE_AP):$(TARGET_COPY_OUT_VENDOR)/firmware/fw_bcmdhd_apsta.bin
+
+ifeq ($(WIFI_DRIVER_BUILT),brcmfmac)
+PRODUCT_COPY_FILES += \
+    vendor/broadcom/wlan/bcmdhd/firmware/bcm43455/$(BCM_FW_SRC_FILE_STA):$(TARGET_COPY_OUT_VENDOR)/firmware/brcm/brcmfmac4359-pcie.bin
+endif


### PR DESCRIPTION
brcmfmac requires for the firmware files to be located under brcm/ and to follow a naming format.
Consider that when brcmfmac is used.