### PR TITLE
[BROADCOM-WLAN] bcm4359: Fix firmware copy

### DIFF
--- a/bcmdhd/firmware/bcm4359/device-bcm-vendor.mk
+++ b/bcmdhd/firmware/bcm4359/device-bcm-vendor.mk
@@ -21,5 +21,5 @@ PRODUCT_COPY_FILES += \
 
 ifeq ($(WIFI_DRIVER_BUILT),brcmfmac)
 PRODUCT_COPY_FILES += \
-    vendor/broadcom/wlan/bcmdhd/firmware/bcm43455/$(BCM_FW_SRC_FILE_STA):$(TARGET_COPY_OUT_VENDOR)/firmware/brcm/brcmfmac4359-pcie.bin
+    vendor/broadcom/wlan/bcmdhd/firmware/bcm4359/$(BCM_FW_SRC_FILE_STA):$(TARGET_COPY_OUT_VENDOR)/firmware/brcm/brcmfmac4359-pcie.bin
 endif


### PR DESCRIPTION
The previous commit added brcmfmac paths to firmware copy.
Unfortunately, that was typoed: fix it.